### PR TITLE
fix: Correct baseurl for GitHub Pages deployment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: The Padhye Family
 description: A family tree and personal space for the Padhye family.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://padhyes.com" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/padhyes-web" # the subpath of your site, e.g. /blog
+url: "https://rahulpadhye.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username:
 github_username:
 


### PR DESCRIPTION
Sets the `baseurl` and `url` in `_config.yml` to the correct values for the GitHub Pages site at `https://rahulpadhye.github.io/padhyes-web/`.

This resolves an issue where CSS and links to other pages were broken (404 errors) on the live site due to incorrect URL pathing. The site should now render correctly.